### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+dist: trusty
 language: java
-jdk: openjdk8
+jdk:
+  - openjdk8
+  - oraclejdk8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 language: java
-jdk:
-  - openjdk8
-  - oraclejdk8
-  - openjdk11     # LTS
-  - oraclejdk11
-  - openjdk-ea    # Early access
-#  - oraclejdk-ea
-
-sudo: true  # https://github.com/travis-ci/travis-ci/issues/6593
+jdk: openjdk8
 
 cache:
   directories:


### PR DESCRIPTION
Usamos trusty como dist, dado que tien versiones de oraclejdk8 pre instaladas