### PR TITLE
Configure test coverage with codacy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ cache:
     - $HOME/.m2
 
 after_success:
-  - ./gradlew jacocoTestReportCodacyUpload --codacy-token $CODACY_PROJECT_TOKEN
+  - ./gradlew jacocoTestReportCodacyUpload --projectToken $CODACY_PROJECT_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ cache:
     - $HOME/.m2
 
 after_success:
-  - ./gradlew jacocoTestReportCodacyUpload
+  - ./gradlew jacocoTestReportCodacyUpload --codacy-token $CODACY_PROJECT_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ jdk:
 cache:
   directories:
     - $HOME/.m2
+
+after_success:
+  - ./gradlew jacocoTestReportCodacyUpload

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ cache:
     - $HOME/.m2
 
 after_success:
-  - ./gradlew jacocoTestReportCodacyUpload --projectToken $CODACY_PROJECT_TOKEN
+  - ./gradlew sendCoverageToCodacy

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ cache:
     - $HOME/.m2
 
 after_success:
+  - ./gradlew jacocoTestReport
   - ./gradlew sendCoverageToCodacy

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 configurations {
+    codacy
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -19,6 +20,8 @@ configurations {
 repositories {
     mavenCentral()
     maven { url 'https://plugins.gradle.org/m2/' }
+    maven { url "https://jitpack.io" }
+    maven { url "http://dl.bintray.com/typesafe/maven-releases" }
 }
 
 dependencies {
@@ -28,6 +31,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation "info.kfgodel:java-spec:$java_spec_version"
+    codacy 'com.github.codacy:codacy-coverage-reporter:-SNAPSHOT'
 }
 
 compileKotlin {
@@ -42,4 +46,16 @@ compileTestKotlin {
         freeCompilerArgs = ['-Xjsr305=strict']
         jvmTarget = '1.8'
     }
+}
+
+task sendCoverageToCodacy(type: JavaExec) {
+    main = "com.codacy.CodacyCoverageReporter"
+    classpath = configurations.codacy
+    args = [
+            "report",
+            "-l",
+            "Java",
+            "-r",
+            "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+    ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-    dependencies {
-        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.14.0"
-    }
-}
-
 plugins {
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id 'org.jetbrains.kotlin.jvm' version '1.3.21'
@@ -11,7 +5,6 @@ plugins {
 }
 
 apply plugin: 'io.spring.dependency-management'
-apply plugin: "com.vanniktech.android.junit.jacoco"
 
 group = 'edu.unq.desapp'
 version = '0.0.1-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+buildscript {
+    dependencies {
+        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.14.0"
+        classpath("gradle.plugin.io.github.ddimtirov:codacy-gradle-plugin:0.1.0")
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id 'org.jetbrains.kotlin.jvm' version '1.3.21'
@@ -5,6 +12,8 @@ plugins {
 }
 
 apply plugin: 'io.spring.dependency-management'
+apply plugin: "com.vanniktech.android.junit.jacoco"
+apply plugin : "io.github.ddimtirov.codacy"
 
 group = 'edu.unq.desapp'
 version = '0.0.1-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     dependencies {
         classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.14.0"
-        classpath("gradle.plugin.io.github.ddimtirov:codacy-gradle-plugin:0.1.0")
     }
 }
 
@@ -13,7 +12,6 @@ plugins {
 
 apply plugin: 'io.spring.dependency-management'
 apply plugin: "com.vanniktech.android.junit.jacoco"
-apply plugin : "io.github.ddimtirov.codacy"
 
 group = 'edu.unq.desapp'
 version = '0.0.1-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://plugins.gradle.org/m2/' }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    dependencies {
+        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.14.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id 'org.jetbrains.kotlin.jvm' version '1.3.21'
@@ -5,6 +11,7 @@ plugins {
 }
 
 apply plugin: 'io.spring.dependency-management'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 group = 'edu.unq.desapp'
 version = '0.0.1-SNAPSHOT'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 kotlin_version=1.3.21
 java_spec_version=2.4.3
+builDir='build'


### PR DESCRIPTION
Se agregan dependencias para generar el reporte de cobertura de tests y enviarlo a través de travis a codacy.com